### PR TITLE
Mute SASS/SCSS deprecation warnings due to Quasar

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -31,6 +31,12 @@ export interface ModuleOptions {
    */
   sassVariables?: string | boolean
 
+  /**
+   * Quasar is pinned to a specific version (1.32.12) of sass, which is causing deprecation warnings polluting the console log when running Nuxt. This function silences 'Using / for division outside of calc() is deprecated' warnings by routing those log messages to a dump.
+   * See an example of this here: https://github.com/quasarframework/quasar/pull/15514#issue-1606006213
+   * Reasoning for Quasar to not fix this: https://github.com/quasarframework/quasar/pull/14213#issuecomment-1219170007
+   */
+  quietSassWarnings?: boolean
   /** Quasar Plugins
    *
    * @see [Documentation](https://quasar.dev/quasar-plugins/)
@@ -73,6 +79,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     sassVariables: false,
+    quietSassWarnings: true,
     plugins: [],
     extras: {}
   },
@@ -161,6 +168,8 @@ export default defineNuxtModule<ModuleOptions>({
           transformAssetUrls
         }
       }
+
+      muteQuasarSassWarnings(config, options)
 
       config.define = {
         ...config.define,
@@ -371,4 +380,77 @@ export function setupCss(css: string[], options: ModuleOptions) {
   }
 
   return css;
+}
+
+/**
+ * Quasar is pinned to a specific version (1.32.12) of sass, which is causing deprecation warnings polluting the console log when running Nuxt. This function silences 'Using / for division outside of calc() is deprecated' warnings by routing those log messages to a dump.
+ * See an example of this here: https://github.com/quasarframework/quasar/pull/15514#issue-1606006213
+ * Reasoning for Quasar to not fix this: https://github.com/quasarframework/quasar/pull/14213#issuecomment-1219170007
+ *
+ * @param config
+ * @param options
+ */
+export function muteQuasarSassWarnings(config: ViteConfig, options: ModuleOptions){
+
+  if (!config || !options || !options.quietSassWarnings) {
+    return;
+  }
+
+  // Source of this fix: https://github.com/quasarframework/quasar/pull/12034#issuecomment-1021503176
+  const silenceSomeSassDeprecationWarnings = {
+    verbose: true,
+    logger: {
+      // @ts-ignore
+      warn(logMessage, logOptions) {
+        const { stderr } = process;
+        const span = logOptions.span ?? undefined;
+        const stack = (logOptions.stack === 'null' ? undefined : logOptions.stack) ?? undefined;
+
+        if (logOptions.deprecation) {
+          if (logMessage.startsWith('Using / for division outside of calc() is deprecated')) {
+            // silences above deprecation warning
+            return;
+          }
+          stderr.write('DEPRECATION ');
+        }
+        stderr.write(`WARNING: ${logMessage}\n`);
+
+        if (span !== undefined) {
+          // output the snippet that is causing this warning
+          stderr.write(`\n"${span.text}"\n`);
+        }
+
+        if (stack !== undefined) {
+          // indent each line of the stack
+          stderr.write(`    ${stack.toString().trimEnd().replace(/\n/gm, '\n    ')}\n`);
+        }
+
+        stderr.write('\n');
+      },
+    },
+  };
+
+  if (!config.css){
+    config.css = {};
+  }
+
+  if (!config.css.preprocessorOptions){
+    config.css.preprocessorOptions = {};
+  }
+
+  const types = ['scss', 'sass'];
+
+  for (const type of types) {
+    if (!config.css.preprocessorOptions[type]) {
+          config.css.preprocessorOptions[type] = {
+            ...silenceSomeSassDeprecationWarnings,
+          }
+        } else {
+          const userConfig = config.css.preprocessorOptions[type];
+          config.css.preprocessorOptions[type] = {
+            ...silenceSomeSassDeprecationWarnings,
+            ...userConfig
+          }
+        }
+  }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -51,7 +51,7 @@ export interface ModuleOptions {
   /** `@quasar/extras` options.
    *
    * @see [Documentation](https://github.com/quasarframework/quasar/blob/dev/extras/README.md)
-  */
+   */
   extras?: {
     font?: QuasarFonts | null
     /** Icons that are imported as webfont. */
@@ -333,7 +333,7 @@ async function getIconsFromIconset(iconSet: QuasarSvgIconSets): Promise<string[]
  */
 export function setupCss(css: string[], options: ModuleOptions) {
 
-  if (!css){
+  if (!css) {
     css = [];
   }
 
@@ -390,7 +390,7 @@ export function setupCss(css: string[], options: ModuleOptions) {
  * @param config
  * @param options
  */
-export function muteQuasarSassWarnings(config: ViteConfig, options: ModuleOptions){
+export function muteQuasarSassWarnings(config: ViteConfig, options: ModuleOptions) {
 
   if (!config || !options || !options.quietSassWarnings) {
     return;
@@ -402,7 +402,7 @@ export function muteQuasarSassWarnings(config: ViteConfig, options: ModuleOption
     logger: {
       // @ts-ignore
       warn(logMessage, logOptions) {
-        const { stderr } = process;
+        const {stderr} = process;
         const span = logOptions.span ?? undefined;
         const stack = (logOptions.stack === 'null' ? undefined : logOptions.stack) ?? undefined;
 
@@ -430,11 +430,11 @@ export function muteQuasarSassWarnings(config: ViteConfig, options: ModuleOption
     },
   };
 
-  if (!config.css){
+  if (!config.css) {
     config.css = {};
   }
 
-  if (!config.css.preprocessorOptions){
+  if (!config.css.preprocessorOptions) {
     config.css.preprocessorOptions = {};
   }
 
@@ -442,15 +442,15 @@ export function muteQuasarSassWarnings(config: ViteConfig, options: ModuleOption
 
   for (const type of types) {
     if (!config.css.preprocessorOptions[type]) {
-          config.css.preprocessorOptions[type] = {
-            ...silenceSomeSassDeprecationWarnings,
-          }
-        } else {
-          const userConfig = config.css.preprocessorOptions[type];
-          config.css.preprocessorOptions[type] = {
-            ...silenceSomeSassDeprecationWarnings,
-            ...userConfig
-          }
-        }
+      config.css.preprocessorOptions[type] = {
+        ...silenceSomeSassDeprecationWarnings,
+      }
+    } else {
+      const userConfig = config.css.preprocessorOptions[type];
+      config.css.preprocessorOptions[type] = {
+        ...silenceSomeSassDeprecationWarnings,
+        ...userConfig
+      }
+    }
   }
 }


### PR DESCRIPTION
Hi there, 

There is this annoying issue where everytime Nuxt v3 is started in dev mode, or when updating any styling, the console is filled with these deprecation warnings coming from Quasar.

[Example](https://github.com/quasarframework/quasar/pull/15514)

Possible fixes were given here: [Stackoverflow](https://stackoverflow.com/questions/67812380/disable-dart-sass-warnings-produced-by-external-theme-file), however none work.

Unfortunately, Quasar is unwilling to fix this as shown by the many attempts by the community to fix this:

- https://github.com/quasarframework/quasar/pull/11877
- https://github.com/quasarframework/quasar/pull/12034
- https://github.com/quasarframework/quasar/pull/14213
- https://github.com/quasarframework/quasar/pull/14816

The main reason being: 
> This has been discussed many times. The "sass" package needs to be pinned to v1.32.12 otherwise, indeed some deprecation warnings will appear. However, it is not easy to convert to the new syntax without adding breaking changes to our developer's apps (a definitely no-go) -- hence the pinning of the "sass" package which should not be touched (manually installed) by our devs (supplied by Quasar CLI).

https://github.com/quasarframework/quasar/pull/14213#issuecomment-1219170007

However, @bompus found a smart workaround here: https://github.com/quasarframework/quasar/pull/12034#issuecomment-1021503176

So I have taken his gist and inserted this into Nuxt-Quasar, toggle-able under an option but is enabled by default, since these specific deprecation warnings are useless for the end-user. 

I have also ensured that any config that is added by the user, is preserved and loaded after this fix. 
Example of how this would look like:
```ts
vite: {
    css: {
        preprocessorOptions: {
            scss: {
                ...silenceSomeSassDeprecationWarnings,
                additionalData: '@use "@/assets/scss/_variables.scss" as *;',
            },
            sass: {
                ...silenceSomeSassDeprecationWarnings,
            },
        },
    },
},
```